### PR TITLE
Remove version from show-plugin btest in prep for 2.7

### DIFF
--- a/tests/Baseline/zeromqwriter.show-plugin/output
+++ b/tests/Baseline/zeromqwriter.show-plugin/output
@@ -1,4 +1,4 @@
-NCSA::ZeroMQWriter - ZeroMQ log writer (dynamic, version 0.2)
+NCSA::ZeroMQWriter - ZeroMQ log writer (dynamic, version)
     [Writer] ZeroMQ (Log::WRITER_ZEROMQ)
     [Constant] LogZeroMQ::endpoint
     [Constant] LogZeroMQ::zmq_hwm

--- a/tests/zeromqwriter/show-plugin.bro
+++ b/tests/zeromqwriter/show-plugin.bro
@@ -1,2 +1,2 @@
-# @TEST-EXEC: bro -NN NCSA::ZeroMQWriter >output
+# @TEST-EXEC: bro -NN NCSA::ZeroMQWriter |sed -e 's/version.*)/version)/g' >output
 # @TEST-EXEC: btest-diff output


### PR DESCRIPTION
Update show-plugin.bro test to remove the version number from the baseline output.
With Bro 2.7, the version will be built from major.minor.patch, which conflicts with
the current major.minor in the baseline.